### PR TITLE
Retire raw emoji from the UI

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,7 @@ android {
         applicationId "me.hadoku.task"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 58
+        versionCode 59
         versionName "3.1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {

--- a/www/index.html
+++ b/www/index.html
@@ -12,7 +12,10 @@
     <div id="landing-screen" class="screen">
         <div class="container">
             <div class="logo">
-                <h1>📝 Hadoku Task</h1>
+                <!-- Inline SVG, not an import: this splash is static HTML with no
+                     bundler. Source of truth is the @wolffm/themes registry
+                     (`note`); regenerate with getIconSvg('note') if it changes. -->
+                <h1><svg xmlns="http://www.w3.org/2000/svg" class="hdk-icon" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M13.4 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7.4" /><path d="M2 6h4" /><path d="M2 10h4" /><path d="M2 14h4" /><path d="M2 18h4" /><path d="M21.378 5.626a1 1 0 1 0-3.004-3.004l-5.01 5.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" /></svg> Hadoku Task</h1>
                 <p class="tagline">Tasks synced, anywhere</p>
             </div>
 


### PR DESCRIPTION
Swaps this repo's raw emoji for the enforced icon set in `@wolffm/themes` (bumped to `^5.5.1`), with `icons.css` imported next to `style.css`. `check-icons` clean.

**Ternary pairs convert together.** Where one arm was flagged and the other wasn't (e.g. `⏳` flagged, `✓` not — U+2713 is a text symbol, not Extended_Pictographic), both still move: an SVG beside a text glyph at a different weight looks worse than leaving both alone.

## Verified
Real build, not just the gate — every one of these PRs had a build catch something the gate didn't.